### PR TITLE
Change timezone long to int

### DIFF
--- a/src/test/java/com/masyaman/datapack/serializers/objects/samples/TsTz.java
+++ b/src/test/java/com/masyaman/datapack/serializers/objects/samples/TsTz.java
@@ -2,12 +2,12 @@ package com.masyaman.datapack.serializers.objects.samples;
 
 public class TsTz {
     protected long ts;
-    protected long tz;
+    protected int tz;
 
     public TsTz() {
     }
 
-    public TsTz(long ts, long tz) {
+    public TsTz(long ts, int tz) {
         this.ts = ts;
         this.tz = tz;
     }
@@ -24,7 +24,7 @@ public class TsTz {
         return tz;
     }
 
-    public void setTz(long tz) {
+    public void setTz(int tz) {
         this.tz = tz;
     }
 


### PR DESCRIPTION
Change timezone long to int

Java TimeZone.getOffset() return int
https://docs.oracle.com/javase/7/docs/api/java/util/TimeZone.html#getOffset(long)
